### PR TITLE
fix exception when data-client-items doesn't exist

### DIFF
--- a/free_bandcamp_downloader/bc_free_downloader.py
+++ b/free_bandcamp_downloader/bc_free_downloader.py
@@ -424,12 +424,15 @@ class BCFreeDownloader:
                     "band_id": int(li["data-band-id"]),
                 }
             )
-        for obj in json.loads(html.unescape(grid.get("data-client-items", {}))):
-            if obj.get("filtered"):
-                continue
-            # normalize to fit the other half
-            obj["url"] = obj.pop("page_url")
-            releases.append(obj)
+
+        client_items = grid.get("data-client-items")
+        if client_items:
+            for obj in json.loads(html.unescape(client_items)):
+                if obj.get("filtered"):
+                    continue
+                # normalize to fit the other half
+                obj["url"] = obj.pop("page_url")
+                releases.append(obj)
 
         # fixup local urls into global ones
         for release in releases:


### PR DESCRIPTION
I somehow had this sitting for months and forgot to pr it

the previous code assumes `data-client-items` exists, but this not the case for artists with few releases (e.g. https://calumbowen.bandcamp.com/). this would raise an exception in `get_url_info`.

this works around it by checking if `data-client-items` exists first before loading it as json.